### PR TITLE
Add german umlauts to regex for items

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export async function parseEBon(dataBuffer: Buffer): Promise<Receipt> {
         };
 
     lines.forEach(line => {
-        const itemHit = line.match(/([0-9A-Za-z %.!+,\-]*) (-?\d*,\d\d) ([AB]) ?(\*?)/);
+        const itemHit = line.match(/([0-9A-Za-zäöüÄÖÜß %.!+,\-]*) (-?\d*,\d\d) ([AB]) ?(\*?)/);
 
         if (itemHit) {
             const item = itemHit[1];


### PR DESCRIPTION
I came across an eBon that was not correctly parsed, because it contained an umlaut because of a campaign (https://www.rewe.de/aktionen/mehrsparplan/). 

Sady the eBon PDFs are password protected since mid of April, so I cannot edit them to provide an anonymized example. Instead take a look at this screenshot:
![Screenshot of an eBon containing items called "alkfr. Getränke"](https://user-images.githubusercontent.com/1002285/87244422-81ec0800-c43d-11ea-94cc-64363bb462bd.png)

This adds the german umlauts to the item regex, which parses the discount as a regular item. I'm not sure if any other special characters could be contained in the item name or if it would be beneficial to parse those discounts in another way.
