### PR TITLE
Add market address

### DIFF
--- a/src/ebon-types.ts
+++ b/src/ebon-types.ts
@@ -31,12 +31,26 @@ export type Payment = {
     value: number
 }
 
+export type MarketAddress = {
+  /** Street of market */
+  street: string;
+
+  /** ZIP of market */
+  zip: number;
+
+  /** City of market */
+  city: string;
+};
+
 export type Receipt = {
     /** Date and time of the purchase */
     date: Date,
 
     /** Market identifier */
     market: string,
+
+    /** Market address */
+    marketAddress?: MarketAddress;
 
     /** Cashier identifier */
     cashier: string,

--- a/src/ebon-types.ts
+++ b/src/ebon-types.ts
@@ -36,7 +36,7 @@ export type MarketAddress = {
   street: string;
 
   /** ZIP of market */
-  zip: number;
+  zip: string;
 
   /** City of market */
   city: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export async function parseEBon(dataBuffer: Buffer): Promise<Receipt> {
     if (addressMatch) {
       marketAddress = {
         street: addressMatch[1].trim(),
-        zip: Number(addressMatch[2]),
+        zip: addressMatch[2],
         city: addressMatch[3].trim(),
       };
     }


### PR DESCRIPTION
I have added the feature to extract the market address from the ebon.

![image](https://user-images.githubusercontent.com/41094392/227724621-72a1c975-f395-4de9-b7f0-e4f41a693eee.png)

```
{
  "market": "0449",
  "marketAddress": {
    "street": "Von-Bodelschwingh-Str. 6",
    "zip": 51061,
    "city": "Köln-Höhenhaus"
  },
  ...
}
```