### PR TITLE
Adds support for tax category C parsing

### DIFF
--- a/src/ebon-types.ts
+++ b/src/ebon-types.ts
@@ -141,5 +141,8 @@ export type TaxDetails = {
     A?: TaxDetailsEntry,
 
     /** Tax on category B items */
-    B?: TaxDetailsEntry
+    B?: TaxDetailsEntry,
+
+    /** Tax on category C items */
+    C?: TaxDetailsEntry
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export async function parseEBon(dataBuffer: Buffer): Promise<Receipt> {
     }
 
     lines.forEach(line => {
-        const itemHit = line.match(/([0-9A-Za-zäöüÄÖÜß &%.!+,\-]*) (-?\d*,\d\d) ([AB]) ?(\*?)/);
+        const itemHit = line.match(/([0-9A-Za-zäöüÄÖÜß &%.!+,\-]*) (-?\d*,\d\d) ([ABC]) ?(\*?)/);
 
         if (itemHit) {
             const item = itemHit[1];
@@ -190,7 +190,7 @@ export async function parseEBon(dataBuffer: Buffer): Promise<Receipt> {
             return;
         }
 
-        const taxDetailsMatch = line.match(/([AB])= ([0-9,]*)% ([0-9,]*) ([0-9,]*) ([0-9,]*)/);
+        const taxDetailsMatch = line.match(/([ABC])= ([0-9,]*)% ([0-9,]*) ([0-9,]*) ([0-9,]*)/);
 
         if (taxDetailsMatch) {
             taxDetails[taxDetailsMatch[1] as TaxCategory] = {


### PR DESCRIPTION
Extends tax category handling to include 'C' in both item and tax detail parsing. Enables processing of receipts with an additional tax category, improving compatibility with updated formats.

fixes #11 